### PR TITLE
Running `gofmt` & cleaning up

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,8 +12,8 @@ func main() {
 	var cfg *service.Config
 
 	if _, err := os.Stat("./mock-ec2-metadata-config.json"); err == nil {
-  		config.LoadJSONFile("./mock-ec2-metadata-config.json", &cfg)
-	} else if _, err := os.Stat("/etc/mock-ec2-metadata-config.json"); err == nil  {
+		config.LoadJSONFile("./mock-ec2-metadata-config.json", &cfg)
+	} else if _, err := os.Stat("/etc/mock-ec2-metadata-config.json"); err == nil {
 		config.LoadJSONFile("/etc/mock-ec2-metadata-config.json", &cfg)
 	} else {
 		server.Log.Fatal("unable to locate config file")

--- a/service/service.go
+++ b/service/service.go
@@ -1,10 +1,10 @@
 package service
 
 import (
-	"fmt"
-	"strings"
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/NYTimes/gizmo/server"
 	"github.com/NYTimes/gizmo/web"
@@ -12,24 +12,24 @@ import (
 
 type (
 	SecurityCredentials struct {
-		User string 			`json:"User"`
-		AccessKeyId string		`json:"AccessKeyId"`
-		SecretAccessKey string	`json:"SecretAccessKey"`
-		Token string			`json:"Token"`
-		Expiration string		`json:"Expiration"`
+		User            string `json:"User"`
+		AccessKeyId     string `json:"AccessKeyId"`
+		SecretAccessKey string `json:"SecretAccessKey"`
+		Token           string `json:"Token"`
+		Expiration      string `json:"Expiration"`
 	}
 
 	MetadataValues struct {
-		Hostname string 							`json:"hostname"`
-		InstanceId string 							`json:"instance-id"`
-		InstanceType string 						`json:"instance-type"`
-		SecurityCredentials SecurityCredentials 	`json:"security-credentials"`
+		Hostname            string              `json:"hostname"`
+		InstanceId          string              `json:"instance-id"`
+		InstanceType        string              `json:"instance-type"`
+		SecurityCredentials SecurityCredentials `json:"security-credentials"`
 	}
 
 	Config struct {
-		Server 				*server.Config
-		MetadataValues 		*MetadataValues
-		MetadataPrefixes	[] string
+		Server           *server.Config
+		MetadataValues   *MetadataValues
+		MetadataPrefixes []string
 	}
 	MetadataService struct {
 		config *Config
@@ -95,8 +95,8 @@ func (s *MetadataService) GetSecurityCredentialDetails(w http.ResponseWriter, r 
 			http.Error(w, "", http.StatusNotFound)
 
 			return
-	 	}else {
-	 		server.Log.Info("GetSecurityCredentialDetails returning: ", details)
+		} else {
+			server.Log.Info("GetSecurityCredentialDetails returning: ", details)
 
 			w.Write(details)
 			return
@@ -111,14 +111,14 @@ func (s *MetadataService) GetSecurityCredentialDetails(w http.ResponseWriter, r 
 
 func (s *MetadataService) GetMetadataIndex(w http.ResponseWriter, r *http.Request) {
 
-	index :=  []string{"hostname",
-					 "instance-id",
-					 "instance-type",
-					 "iam/"}
+	index := []string{"hostname",
+		"instance-id",
+		"instance-type",
+		"iam/"}
 	w.Header().Add("Content-Type", "text/plain; charset=utf-8")
 	res := fmt.Sprint(strings.Join(index, "\n"))
 	server.Log.Info("GetMetadataIndex returning: ", res)
-	fmt.Fprintf(w, res )
+	fmt.Fprintf(w, res)
 	return
 }
 
@@ -134,25 +134,25 @@ func (service *MetadataService) Endpoints() map[string]map[string]http.HandlerFu
 	for index, value := range service.config.MetadataPrefixes {
 		server.Log.Info("adding Metadata prefix (", index, ") ", value)
 
-		handlers[value + "/" ] = map[string]http.HandlerFunc{
+		handlers[value+"/"] = map[string]http.HandlerFunc{
 			"GET": service.GetMetadataIndex,
 		}
-		handlers[value + "/hostname" ] = map[string]http.HandlerFunc{
+		handlers[value+"/hostname"] = map[string]http.HandlerFunc{
 			"GET": service.GetHostName,
 		}
-		handlers[value + "/instance-id" ] = map[string]http.HandlerFunc{
+		handlers[value+"/instance-id"] = map[string]http.HandlerFunc{
 			"GET": service.GetInstanceId,
 		}
-		handlers[value + "/instance-type" ] = map[string]http.HandlerFunc{
+		handlers[value+"/instance-type"] = map[string]http.HandlerFunc{
 			"GET": service.GetInstanceType,
 		}
-		handlers[value + "/iam/" ] = map[string]http.HandlerFunc{
+		handlers[value+"/iam/"] = map[string]http.HandlerFunc{
 			"GET": service.GetIAM,
 		}
-		handlers[value + "/iam/security-credentials/" ] = map[string]http.HandlerFunc{
+		handlers[value+"/iam/security-credentials/"] = map[string]http.HandlerFunc{
 			"GET": service.GetSecurityCredentials,
 		}
-		handlers[value + "/iam/security-credentials/{username}" ] = map[string]http.HandlerFunc{
+		handlers[value+"/iam/security-credentials/{username}"] = map[string]http.HandlerFunc{
 			"GET": service.GetSecurityCredentialDetails,
 		}
 	}

--- a/service/service.go
+++ b/service/service.go
@@ -44,11 +44,11 @@ func (s *MetadataService) Middleware(h http.Handler) http.Handler {
 }
 
 // middleware for adding plaintext content type
-func plainText(h http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+func plainText(h http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("Content-Type", "text/plain; charset=utf-8")
-		h.ServeHTTP(w, r)
-	})
+		h(w, r)
+	}
 }
 
 func (s *MetadataService) GetHostName(w http.ResponseWriter, r *http.Request) {
@@ -60,7 +60,7 @@ func (s *MetadataService) GetInstanceId(w http.ResponseWriter, r *http.Request) 
 }
 
 func (s *MetadataService) GetInstanceType(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprintf(s.config.MetadataValues.InstanceType)
+	fmt.Fprintf(w, s.config.MetadataValues.InstanceType)
 }
 
 func (s *MetadataService) GetIAM(w http.ResponseWriter, r *http.Request) {
@@ -88,7 +88,7 @@ func (s *MetadataService) GetSecurityCredentialDetails(w http.ResponseWriter, r 
 		return
 	}
 
-	server.LogWithFiels(r).Info("GetSecurityCredentialDetails returning: %#v",
+	server.LogWithFields(r).Info("GetSecurityCredentialDetails returning: %#v",
 		s.config.MetadataValues.SecurityCredentials)
 }
 

--- a/service/service.go
+++ b/service/service.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/NYTimes/gizmo/server"
 	"github.com/NYTimes/gizmo/web"
@@ -44,113 +43,89 @@ func (s *MetadataService) Middleware(h http.Handler) http.Handler {
 	return h
 }
 
+// middleware for adding plaintext content type
+func plainText(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "text/plain; charset=utf-8")
+		h.ServeHTTP(w, r)
+	})
+}
+
 func (s *MetadataService) GetHostName(w http.ResponseWriter, r *http.Request) {
-	w.Header().Add("Content-Type", "text/plain; charset=utf-8")
-	res := fmt.Sprint(s.config.MetadataValues.Hostname)
-	fmt.Fprintf(w, res)
-	server.Log.Info("GetHostName returning: ", res)
-	return
+	fmt.Fprintf(w, s.config.MetadataValues.Hostname)
 }
 
 func (s *MetadataService) GetInstanceId(w http.ResponseWriter, r *http.Request) {
-	w.Header().Add("Content-Type", "text/plain; charset=utf-8")
-	res := fmt.Sprint(s.config.MetadataValues.InstanceId)
-	fmt.Fprintf(w, res)
-	server.Log.Info("GetInstanceId returning: ", res)
-	return
+	fmt.Fprintf(w, s.config.MetadataValues.InstanceId)
 }
 
 func (s *MetadataService) GetInstanceType(w http.ResponseWriter, r *http.Request) {
-	w.Header().Add("Content-Type", "text/plain; charset=utf-8")
-	res := fmt.Sprint(s.config.MetadataValues.InstanceType)
-	fmt.Fprintf(w, res)
-	server.Log.Info("GetInstanceType returning: ", res)
-	return
+	fmt.Fprintf(s.config.MetadataValues.InstanceType)
 }
 
 func (s *MetadataService) GetIAM(w http.ResponseWriter, r *http.Request) {
-	w.Header().Add("Content-Type", "text/plain; charset=utf-8")
-	res := fmt.Sprint("security-credentials/")
-	fmt.Fprintf(w, res)
-	server.Log.Info("GetIAM returning: ", res)
-	return
+	fmt.Fprintf(w, "security-credentials/")
 }
 
 func (s *MetadataService) GetSecurityCredentials(w http.ResponseWriter, r *http.Request) {
-	w.Header().Add("Content-Type", "text/plain; charset=utf-8")
-	res := fmt.Sprint(s.config.MetadataValues.SecurityCredentials.User)
-	server.Log.Info("GetSecurityCredentials returning: ", res)
-	fmt.Fprintf(w, res)
-	return
+	fmt.Fprintf(w, s.config.MetadataValues.SecurityCredentials.User)
 }
 
 func (s *MetadataService) GetSecurityCredentialDetails(w http.ResponseWriter, r *http.Request) {
-	w.Header().Add("Content-Type", "text/plain; charset=utf-8")
 	username := web.Vars(r)["username"]
 
-	if username == s.config.MetadataValues.SecurityCredentials.User {
-		details, err := json.MarshalIndent(s.config.MetadataValues.SecurityCredentials, "", "\t")
-		if err != nil {
-			server.Log.Error("error converting security credentails to json: ", err)
-			http.Error(w, "", http.StatusNotFound)
-
-			return
-		} else {
-			server.Log.Info("GetSecurityCredentialDetails returning: ", details)
-
-			w.Write(details)
-			return
-		}
-	} else {
+	if username != s.config.MetadataValues.SecurityCredentials.User {
 		server.Log.Error("error, IAM user not found")
 		http.Error(w, "", http.StatusNotFound)
+		return
 	}
 
-	return
+	w.Header().Add("Content-Type", "application/json; charset=utf-8")
+	err := json.NewEncoder(w).Encode(s.config.MetadataValues.SecurityCredentials)
+	if err != nil {
+		server.Log.Error("error converting security credentails to json: ", err)
+		http.Error(w, "", http.StatusNotFound)
+		return
+	}
+
+	server.LogWithFiels(r).Info("GetSecurityCredentialDetails returning: %#v",
+		s.config.MetadataValues.SecurityCredentials)
 }
 
 func (s *MetadataService) GetMetadataIndex(w http.ResponseWriter, r *http.Request) {
-
-	index := []string{"hostname",
-		"instance-id",
-		"instance-type",
-		"iam/"}
-	w.Header().Add("Content-Type", "text/plain; charset=utf-8")
-	res := fmt.Sprint(strings.Join(index, "\n"))
-	server.Log.Info("GetMetadataIndex returning: ", res)
-	fmt.Fprintf(w, res)
-	return
+	fmt.Fprintf(w, `hostname
+instance-id
+instance-type
+iam`)
 }
 
 func (s *MetadataService) GetIndex(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "Mock EC2 Metadata Service")
-	return
 }
 
 // Endpoints is a listing of all endpoints available in the MetadataService.
 func (service *MetadataService) Endpoints() map[string]map[string]http.HandlerFunc {
+	handlers := map[string]map[string]http.HandlerFunc{}
 
-	handlers := make(map[string]map[string]http.HandlerFunc)
 	for index, value := range service.config.MetadataPrefixes {
 		server.Log.Info("adding Metadata prefix (", index, ") ", value)
-
 		handlers[value+"/"] = map[string]http.HandlerFunc{
-			"GET": service.GetMetadataIndex,
+			"GET": plainText(service.GetMetadataIndex),
 		}
 		handlers[value+"/hostname"] = map[string]http.HandlerFunc{
-			"GET": service.GetHostName,
+			"GET": plainText(service.GetHostName),
 		}
 		handlers[value+"/instance-id"] = map[string]http.HandlerFunc{
-			"GET": service.GetInstanceId,
+			"GET": plainText(service.GetInstanceId),
 		}
 		handlers[value+"/instance-type"] = map[string]http.HandlerFunc{
-			"GET": service.GetInstanceType,
+			"GET": plainText(service.GetInstanceType),
 		}
 		handlers[value+"/iam/"] = map[string]http.HandlerFunc{
-			"GET": service.GetIAM,
+			"GET": plainText(service.GetIAM),
 		}
 		handlers[value+"/iam/security-credentials/"] = map[string]http.HandlerFunc{
-			"GET": service.GetSecurityCredentials,
+			"GET": plainText(service.GetSecurityCredentials),
 		}
 		handlers[value+"/iam/security-credentials/{username}"] = map[string]http.HandlerFunc{
 			"GET": service.GetSecurityCredentialDetails,


### PR DESCRIPTION
First step of cleaning up Go code: Always run `gofmt`. You can set up your editor (i.e. vim-go) to run `gofmt` (or even `goimports`!) on save and your life will be better.

I'd recommend a walk through the Google Go code review style guide: https://github.com/golang/go/wiki/CodeReviewComments
- added a middleware for wrapping the `plain/text` endpoints to add the Content-Type.
- removed most logs but added use of gizmo's `server.LogWithFields(r)` to add additional meta when applicable.
- rearranged `GetSecurityCredentialDetails` to fail fast instead of using multiple, nested 'else' blocks. This makes it a tad easier to read and more in line with normal Go code. 
