### PR TITLE
Add redirect for security credentials endpoint without trailing slash

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -66,6 +66,12 @@ func plainText(h http.HandlerFunc) http.HandlerFunc {
 	}
 }
 
+func movedPermanently(redirectPath string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, redirectPath, http.StatusMovedPermanently)
+	}
+}
+
 func (s *MetadataService) GetAmiId(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, s.config.MetadataValues.AmiId)
 }
@@ -204,6 +210,9 @@ func (service *MetadataService) Endpoints() map[string]map[string]http.HandlerFu
 		}
 		handlers[value+"/iam/"] = map[string]http.HandlerFunc{
 			"GET": plainText(service.GetIAM),
+		}
+		handlers[value+"/iam/security-credentials"] = map[string]http.HandlerFunc{
+			"GET": movedPermanently(value + "/iam/security-credentials/"),
 		}
 		handlers[value+"/iam/security-credentials/"] = map[string]http.HandlerFunc{
 			"GET": plainText(service.GetSecurityCredentials),


### PR DESCRIPTION
Add redirect from http://169.254.169.254/latest/meta-data/iam/security-credentials to http://169.254.169.254/latest/meta-data/iam/security-credentials/

This is how the AWS implementation behaves right now and some libraries (e.g. aws-sdk-go) seem to rely on this