### PR TITLE
Add "Code" field to security credentials.

### DIFF
--- a/mock-ec2-metadata-config.json
+++ b/mock-ec2-metadata-config.json
@@ -22,7 +22,8 @@
             "AccessKeyId" : "mock-access-key",
             "SecretAccessKey" : "mock-secret-key",
             "Token": "mock-token",
-            "Expiration": "2112-12-31T11:59:59Z"
+            "Expiration": "2112-12-31T11:59:59Z",
+            "Code": "Success"
         },
         "security-groups": [
             "mock-security-group"

--- a/service/service.go
+++ b/service/service.go
@@ -17,6 +17,7 @@ type (
 		SecretAccessKey string `json:"SecretAccessKey"`
 		Token           string `json:"Token"`
 		Expiration      string `json:"Expiration"`
+		Code            string `json:"Code"`
 	}
 
 	MetadataValues struct {


### PR DESCRIPTION
The aws-sdk-go [seems to check](https://github.com/aws/aws-sdk-go/blob/db3e1e27b1ace4fc57be9c5cf7cea0566bd12034/aws/credentials/ec2rolecreds/ec2_role_provider.go#L172) the `Code` field in the security credentials response.