### PR TITLE
Fix build problems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 bin
+mock-metadata-access.log
+mock-metadata-app.log

--- a/Godeps
+++ b/Godeps
@@ -1,1 +1,1 @@
-github.com/NYTimes/gizmo 12c3a2a0a5dcc7cdc6f3d13b1ceae135872f786a
+github.com/NYTimes/gizmo bb17238799b62b40a3bcb83a072d980562071436

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ deps:
 	go get github.com/mtibben/gogpm
 	go get github.com/tcnksm/ghr
 	go get github.com/mitchellh/gox
+	go get github.com/Sirupsen/logrus
 	$(GOPATH)/bin/gogpm install
 
 build:


### PR DESCRIPTION
Fixes #14 
* Updated gizmo to [v0.2.2](https://github.com/NYTimes/gizmo/releases/tag/v0.2.2) the latest version as of Nov 3rd, 2018
* Added Sirupsen/logrus to [Godeps](Godeps) to fix error during `make deps`
* Added log files to gitignore to keep git workspace clear